### PR TITLE
fix: admin 신청 관리 결과 css수정 (#00)

### DIFF
--- a/src/app/admin/AdminLayout.css.js
+++ b/src/app/admin/AdminLayout.css.js
@@ -4,31 +4,40 @@ import { vars } from '@/styles/tokens.css';
 export const adminRoot = style({
   display: 'flex',
   flexDirection: 'column',
-  minHeight: '100vh',
+  minHeight: '100dvh',
   backgroundColor: vars.color.gray[50],
-  minWidth: '375px',
+  width: '100%',
 });
 
 export const adminMain = style({
   flex: 1,
   backgroundColor: vars.color.white,
-  paddingTop: '24px',
-  paddingBottom: vars.space['2xl'],
+  paddingTop: vars.space.lg,
+  paddingBottom: vars.space.xl,
+  width: '100%',
+  '@media': {
+    'screen and (min-width: 745px)': {
+      paddingTop: '24px',
+      paddingBottom: vars.space['2xl'],
+    },
+  },
 });
 
 export const contentContainer = style({
+  width: '100%',
   maxWidth: '1200px',
   margin: '0 auto',
-  width: '100%',
-  padding: `0 ${vars.space.xl}`,
+  paddingLeft: vars.space.md,
+  paddingRight: vars.space.md,
+  boxSizing: 'border-box',
   '@media': {
-    'screen and (max-width: 744px)': {
-      maxWidth: '744px',
-      padding: `0 ${vars.space.lg}`,
+    'screen and (min-width: 376px)': {
+      paddingLeft: vars.space.lg,
+      paddingRight: vars.space.lg,
     },
-    'screen and (max-width: 375px)': {
-      width: '375px',
-      padding: `0 ${vars.space.md}`,
+    'screen and (min-width: 745px)': {
+      paddingLeft: vars.space.xl,
+      paddingRight: vars.space.xl,
     },
   },
 });

--- a/src/app/admin/_components/OriginalUrlSection.css.js
+++ b/src/app/admin/_components/OriginalUrlSection.css.js
@@ -13,7 +13,19 @@ export const title = style({
 });
 
 export const relativeWrapper = style({
-  position: 'relative',
+  width: '100%',
+  margin: '0 auto',
+  overflow: 'hidden',
+  height: 'auto',
+  objectFit: 'cover',
+  '@media': {
+    'screen and (max-width: 743px)': {
+      width: '375px',
+      height: '206px',
+      maxWidth: '100%',
+      margin: '0 auto',
+    },
+  },
 });
 
 export const buttonPos = style({

--- a/src/app/admin/_components/StatusSection.css.js
+++ b/src/app/admin/_components/StatusSection.css.js
@@ -6,7 +6,6 @@ export const commonBtnStyle = style({
   alignItems: 'center',
   width: '100%',
   height: '35px',
-  margin: '24px 0',
   borderRadius: '17.5px',
   fontSize: '14px',
   fontWeight: 600,

--- a/src/app/admin/management/[id]/Page.css.js
+++ b/src/app/admin/management/[id]/Page.css.js
@@ -26,15 +26,16 @@ export const innerWrapper = style({
   flexDirection: 'column',
   boxSizing: 'border-box',
   padding: '32px',
+  gap: '16px',
 
   '@media': {
     'screen and (max-width: 1199px)': {
       maxWidth: '744px',
-      padding: '32px 24px',
+      padding: 0,
     },
     'screen and (max-width: 743px)': {
       maxWidth: '375px',
-      padding: '24px 16px',
+      padding: 0,
     },
   },
 });

--- a/src/shared/components/GNB/GNB.css.js
+++ b/src/shared/components/GNB/GNB.css.js
@@ -37,13 +37,22 @@ export const inner = style({
   boxSizing: 'border-box',
   maxWidth: 1200,
   margin: '0 auto',
+  minWidth: 0,
 });
 
 export const left = style({
   display: 'flex',
   alignItems: 'center',
   gap: 24,
-  flexShrink: 0,
+  flexShrink: 1,
+  minWidth: 0,
+
+  '@media': {
+    'screen and (max-width: 743px)': {
+      gap: 12,
+      flex: 1,
+    },
+  },
 });
 
 export const right = style({
@@ -51,6 +60,12 @@ export const right = style({
   alignItems: 'center',
   gap: 16,
   flexShrink: 0,
+
+  '@media': {
+    'screen and (max-width: 743px)': {
+      gap: 8,
+    },
+  },
 });
 
 export const logo = style({
@@ -92,6 +107,8 @@ export const tabs = style({
   display: 'flex',
   alignItems: 'stretch',
   gap: 0,
+  minWidth: 0,
+  flexShrink: 1,
 });
 
 const tabTransition = `color ${vars.transition.duration.normal} ${vars.transition.timing.ease}, background-color ${vars.transition.duration.normal} ${vars.transition.timing.ease}`;
@@ -111,6 +128,16 @@ const tabBase = style({
   textDecoration: 'none',
   transition: tabTransition,
   outline: 'none',
+  whiteSpace: 'nowrap',
+  minWidth: 0,
+
+  '@media': {
+    'screen and (max-width: 743px)': {
+      padding: '18px 8px',
+      fontSize: '13px',
+    },
+  },
+
   selectors: {
     '&:hover': {
       color: vars.color.gray[700],


### PR DESCRIPTION
## 🔧 작업 내용 요약

- 어드민 신청관리 결과(승인, 거절)페이지 반응형 css 수정
- width744,375 피그마랑 비?슷 하게 완성..

## 📸 스크린샷
wid375
<img width="193" height="458" alt="m Dochr" src="https://github.com/user-attachments/assets/48db4b8f-f070-41b8-8ac7-2dc5ed2fab42" />
width744
<img width="378" height="601" alt="Css0점 테스트" src="https://github.com/user-attachments/assets/59d050cc-5987-4958-80e2-e439321478d7" />

왼쪽 회색부분은 부분캡쳐하다가 배경도 같이 찍힌거니 무시해주세요..

## 📣 팀원들에게 공유할 내용 / 도움 요청

<!-- 새로 설치한 패키지 등 팀과 공유 해야 할 내용 -->
<!-- 도움 및 리뷰가 필요한 부분이 있다면 공유 -->

## 🔗 관련 이슈

<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
<!-- 여기에 " closes #이슈번호 " 를 적으면 이슈가 자동으로 종료됩니다 -->
